### PR TITLE
[ATL-306] fix caller 

### DIFF
--- a/zap/zap.go
+++ b/zap/zap.go
@@ -15,7 +15,7 @@ func Init() (*Logger, error) {
 		return nil, errors.Wrap(err, "Build Zap Config")
 	}
 
-	sugarLog := zLogger.Sugar()
+	sugarLog := zLogger.WithOptions(zap.AddCallerSkip(1)).Sugar()
 
 	return &Logger{sugarLog}, nil
 }


### PR DESCRIPTION
Skipping 1 caller level. The logger always shows "caller:zap/wrapper.go:63"

Proof:

Before:
![image](https://github.com/user-attachments/assets/ddbd0a99-8608-494e-8e76-7e85fd2e0f47)


After:
![image](https://github.com/user-attachments/assets/2b9076a5-3547-4c0d-a08b-db57275c7374)
