### PR TITLE
[ATL-318] add matched route to logs

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -8,6 +8,7 @@ const (
 	Method           = "method"
 	URI              = "uri"
 	Path             = "path"
+	Route            = "route"
 	External         = "external"
 	Status           = "status"
 	UserAgent        = "user_agent"

--- a/zap/middleware.go
+++ b/zap/middleware.go
@@ -42,6 +42,7 @@ func (w *Logger) EchoMiddleware() echo.MiddlewareFunc {
 			appendFilledFieldsOnly(&fields, key.Method, req.Method)
 			appendFilledFieldsOnly(&fields, key.URI, req.RequestURI)
 			appendFilledFieldsOnly(&fields, key.Path, req.URL.Path)
+			appendFilledFieldsOnly(&fields, key.Route, c.Path())
 			appendFilledFieldsOnly(&fields, key.Status, res.Status)
 			appendFilledFieldsOnly(&fields, key.UserAgent, req.UserAgent())
 			appendFilledFieldsOnly(&fields, key.APIVersion, req.Header.Get("API-Version"))


### PR DESCRIPTION
# Description

Field "route" added.

# Example

¿How would it look like?

```
{
    "level": "info",
    "ts": 1747144666.249525,
    "caller": "zap/middleware.go:80",
    "msg": "Info",
    "email": "demo-pd@leadjet.io",
    "company_key": "PIPEDRIVE7489242",
    "correlation_id": "b8C6JOv6mEkpJzFQEYgM2RWs7eZkTEcc",
    "api_version": "DEV",
    "remote_ip": "::1",
    "external": false,
    "email": "demo-pd@leadjet.io",
    "company_key": "PIPEDRIVE7489242",
    "processing_time": 14,
    "method": "GET",
    "uri": "/v1/people/enrichments/bulk/0196c517-324b-7a7b-91d7-5d8aa482c56b",
    "path": "/v1/people/enrichments/bulk/0196c517-324b-7a7b-91d7-5d8aa482c56b",
    "route": "/v1/people/enrichments/bulk/:id",
    "status": 200,
    "user_agent": "PostmanRuntime/7.43.4",
    "correlation_id": "b8C6JOv6mEkpJzFQEYgM2RWs7eZkTEcc"
}
```