### PR TITLE
[PLAT-127] Export logger context key

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -32,10 +32,10 @@ const (
 	HeaderCompanyKey    = "company-key"
 )
 
-type ctxKey int
+type LoggerCtxKey int
 
 const (
-	CtxEmail ctxKey = iota
+	CtxEmail LoggerCtxKey = iota
 	CtxCompany
 	CtxCorrelationID
 	CtxTool


### PR DESCRIPTION
Needed to be able to use this in the context propagator for Temporal to ensure we have consistent logs inside and outside of Temporal.